### PR TITLE
embedded gist test

### DIFF
--- a/clean-arch.html
+++ b/clean-arch.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en-UK">
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="author" content="Adam Munro"/>
+    <meta name="description" content="Index of stuff I wrote."/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+
+    <!-- refresh page every x seconds -->
+    <!--meta http-equiv="refresh" content="5"/-->
+
+    <title>adjmunro's blog?</title>
+    
+    <link rel="stylesheet" type="text/css" href="./default.css"/>
+    <script src="https://gist.github.com/adjmunro/048929eccfd8af176545e4ff609839e9.js"></script>
+</head>
+<body>
+  <script src="https://gist.github.com/adjmunro/048929eccfd8af176545e4ff609839e9.js"></script>
+</body>
+</html>


### PR DESCRIPTION
This pull request adds a new HTML file, `clean-arch.html`, which appears to serve as a basic blog page template. The file includes metadata, a link to a stylesheet, and a script from a GitHub Gist.

### Key changes:

#### Added HTML structure for a blog page:
* Created a new `clean-arch.html` file with a basic HTML5 structure, including a `<head>` section with metadata (`author`, `description`, `viewport`) and a `<title>` tag.
* Linked an external stylesheet (`default.css`) for styling and included a script from a GitHub Gist for additional functionality.